### PR TITLE
PO-30 ORCA dla Policji

### DIFF
--- a/StanLakeside.Jackson_County/core/config/fn_vehicleListCfg.sqf
+++ b/StanLakeside.Jackson_County/core/config/fn_vehicleListCfg.sqf
@@ -1898,11 +1898,13 @@ switch (_shop) do
 	{
 		_return =
 		[			
+			/*["EC_135_F",45000],*/
 			["B_Heli_Light_01_F",45000],
 			["C_Heli_Light_01_civil_F",45000],
-			/*["EC_135_F",45000],*/
 			["kif_vehicles_helicopter_mh9_police",85000],
-			["melb_h6m",85000]
+			["melb_h6m",85000],
+			["A3_Air_F_Heli_Light_02",100000]
+
 		];
 	};
 	case "cop_airhq":


### PR DESCRIPTION
Dodanie PO 30 ORCA (czarna nie uzbrojona)dla Policji. Dla SERT